### PR TITLE
[diskencryption] Add kernel-module-dm-mod as recommended

### DIFF
--- a/recipes-crypto/diskencryption/diskencryption.bb
+++ b/recipes-crypto/diskencryption/diskencryption.bb
@@ -18,6 +18,10 @@ RDEPENDS_${PN} = " \
     jq \
 "
 
+RRECOMMENDS_${PN} += " \
+    kernel-module-dm-mod \
+"
+
 FILES_${PN} = " \
     ${bindir}/diskencryption.sh \
 "


### PR DESCRIPTION
Diskencryption required block device mapper (DM) to be enabled in kernel. Add this kernel module to recipe recommends.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>