### PR TITLE
Set the priority of the layer to 10

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "aos"
 BBFILE_PATTERN_aos = "^${LAYERDIR}/"
-BBFILE_PRIORITY_aos = "6"
+BBFILE_PRIORITY_aos = "10"
 
 LAYERSERIES_COMPAT_aos = "thud warrior zeus dunfell"
 LAYERDEPENDS_aos = "virtualization-layer"


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```