### PR TITLE
[mssageproxy] Use CM certificate for vchan

### DIFF
--- a/recipes-aos/aos-messageproxy/files/aos_messageproxy.cfg
+++ b/recipes-aos/aos-messageproxy/files/aos_messageproxy.cfg
@@ -14,7 +14,7 @@
         "XSOpenTXPath": "tmp/vchan/aos/open/tx",
         "XSSecureRXPath": "tmp/vchan/aos/secure/rx",
         "XSSecureTXPath": "tmp/vchan/aos/secure/tx",
-        "CertStorage": "sm",
+        "CertStorage": "cm",
         "Domain": 0
     },
     "Downloader": {


### PR DESCRIPTION
SM is client only certificate, we should use CM certificate for vchan.