### PR TITLE
[all] Use Requires in journal-flush.service for var.mount

### DIFF
--- a/recipes-core/systemd/systemd/systemd-journal-flush-override.conf
+++ b/recipes-core/systemd/systemd/systemd-journal-flush-override.conf
@@ -1,3 +1,3 @@
 [Unit]
-Wants=var.mount
+Requires=var.mount
 After=var.mount


### PR DESCRIPTION
It looks like "Wants" is not enough to set a dependency on var.mount. Because journald blocked var partition on shutdown, which led to the alert mentioned in the ticket EPMDAEPR-3653