### PR TITLE
[openssl] Activate default & legacy providers

### DIFF
--- a/recipes-connectivity/openssl/files/openssl-engine.conf
+++ b/recipes-connectivity/openssl/files/openssl-engine.conf
@@ -1,3 +1,12 @@
+[provider_sect]
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+
 [openssl_init]
 engines=engine_section
 


### PR DESCRIPTION
Default provider contains a main set of built-in crypto algorithms. Legacy provider activated to be consistent with poco library. Because the latter one activates it explicitly.