### PR TITLE
[scripts] Create dir path for output image

### DIFF
--- a/scripts/fota_builder.py
+++ b/scripts/fota_builder.py
@@ -41,6 +41,9 @@ class FotaBuilder:
 
     def create_bundle(self):
         """Create bundle from prepared files"""
+
+        self._prepare_dir(os.path.dirname(self._bundle_name))
+
         args = ["tar", "-cf", self._bundle_name, "-C", self._bundle_dir, "."]
 
         self._run_cmd(args)


### PR DESCRIPTION
Scrips doesn't create full dir path for output image. It causes bundle creation error in case multiple dir path used.