### PR TITLE
[fota_builder] Populate runtime dependencies to meta file

### DIFF
--- a/scripts/fota_builder.py
+++ b/scripts/fota_builder.py
@@ -112,6 +112,29 @@ class FotaBuilder:
         if var:
             metadata[varname] = var.as_str
 
+    def _add_runtime_dependencies(self, metadata, conf):
+        runtime_deps = conf.get("runtimeDependencies", None)
+
+        if runtime_deps is None:
+            return
+
+        meta_dependencies = []
+
+        for dependency in runtime_deps:
+            if len(dependency) == 0:
+                continue
+
+            meta_dependency = {
+                "id": dependency["id"].as_str,
+                "requiredVersion": dependency["requiredVersion"].as_str,
+                "minVersion": dependency.get("minVersion", "").as_str
+            }
+
+            # Add dependency with non-empty values only
+            meta_dependencies.append({k: v for k, v in meta_dependency.items() if v})
+
+        metadata["runtimeDependencies"] = meta_dependencies
+
     def _create_component_metadata(self, component, conf):
         metadata = {
             "type": conf.get("componentType", component).as_str,
@@ -127,6 +150,8 @@ class FotaBuilder:
         self._update_metadata_var(conf, "description", metadata)
         self._update_metadata_var(conf, "annotations", metadata)
         self._update_metadata_var(conf, "downloadTTL", metadata)
+
+        self._add_runtime_dependencies(metadata, conf)
 
         return metadata
 


### PR DESCRIPTION
yaml file incremental component:

```
      components:
        rootfs-incremental:
          componentType: "%{UNIT_MODEL}-%{UNIT_VERSION}-%{NODE_TYPE}-rootfs"
          enabled: true
          method: "overlay"
          ostree_repo: "../../ostree_repo/%{UNIT_MODEL}-%{UNIT_VERSION}-%{NODE_TYPE}-rootfs"
          yocto_dir: "../%{YOCTOS_WORK_DIR}"
          build_dir: "build-%{NODE_TYPE}"
          type: "incremental"
          description: "%{NODE_TYPE} rootfs image"
          version: "%{BUNDLE_IMAGE_VERSION}"
          requiredVersion: "%{ROOTFS_REF_VERSION}"
          exclude:
            - "home/*"
            - "var/*"
          fileName: "%{UNIT_MODEL}-%{UNIT_VERSION}-%{NODE_TYPE}-rootfs-incremental-%{BUNDLE_IMAGE_VERSION}.squashfs"
          runtimeDependencies:
            - id: "boot"
              requiredVersion: "%{BUNDLE_IMAGE_VERSION}"
```

Resulting meta file:
```
{
    "formatVersion": 2,
    "components": [
        {
            "type": "vm-dev-dynamic-1.0-main-rootfs",
            "version": "5.0.2",
            "fileName": "vm-dev-dynamic-1.0-main-rootfs-incremental-5.0.2.squashfs",
            "requiredVersion": "5.0.0",
            "description": "main rootfs image",
            "runtimeDependencies": [
                {
                    "id": "boot",
                    "requiredVersion": "5.0.2"
                }
            ],
            "annotations": {
                "type": "incremental"
            }
        }
    ]
}

```