### PR TITLE
[aos-setupdisk] Remove mount dirs on disk setup delete

### DIFF
--- a/recipes-aos/aos-setupdisk/files/setupdisk.sh
+++ b/recipes-aos/aos-setupdisk/files/setupdisk.sh
@@ -117,6 +117,7 @@ delete_aos_disks() {
 
         if mountpoint -q "$mountdir"; then
             umount "$mountdir"
+            rm -rf "$mountdir"
         fi
 
     done <"$CONFIG_FILE"


### PR DESCRIPTION
Mount directories are created during disk setup, but they are not removed when the disk setup delete command is executed. This patch makes disk setup create and delete comands consistent.