### PR TITLE
recipes-aos: do not update CM server option

### DIFF
--- a/recipes-aos/aos-communicationmanager/aos-communicationmanager_git.bb
+++ b/recipes-aos/aos-communicationmanager/aos-communicationmanager_git.bb
@@ -73,10 +73,6 @@ python do_update_config() {
     data["iamProtectedServerUrl"]= node_hostname + ":8089"
     data["iamPublicServerUrl"] = node_hostname + ":8090"
 
-    # Update CM server
-
-    data["cmServerUrl"] = node_hostname + ":8093"
-
     # Update DNS IP
 
     dns_ip = d.getVar("AOS_DNS_IP")


### PR DESCRIPTION
CM server option should be defined in product meta layers and should not be updated automatically.