### PR TITLE
recipes-extended: quota: add systemd service to enable rpc.quotad

### DIFF
--- a/recipes-extended/quota/files/rpc-rquotad.service
+++ b/recipes-extended/quota/files/rpc-rquotad.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Remote quota server
+Documentation=man:rpc.rquotad(8)
+Requires=rpcbind.service
+PartOf=rpcbind.service
+After=rpcbind.service
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/rpc.rquotad
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=nfs-server.service

--- a/recipes-extended/quota/quota_%.bbappend
+++ b/recipes-extended/quota/quota_%.bbappend
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://rpc-rquotad.service \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "rpc-rquotad.service"
+
+FILES:${PN} += "${systemd_system_unitdir}/rpc-rquotad.service"
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/rpc-rquotad.service ${D}${systemd_system_unitdir}
+}


### PR DESCRIPTION
rpc.quotad daemon required to retrieve quotas on remote nodes on disk mounted by nfs.