### PR TITLE
recipes-extended: start rpc-rquotad after network-online service

### DIFF
--- a/recipes-extended/quota/files/rpc-rquotad.service
+++ b/recipes-extended/quota/files/rpc-rquotad.service
@@ -3,7 +3,7 @@ Description=Remote quota server
 Documentation=man:rpc.rquotad(8)
 Requires=rpcbind.service
 PartOf=rpcbind.service
-After=rpcbind.service
+After=rpcbind.service network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
rpc-rquotad doesn't work if started before network-online service.