### PR TITLE
openssl: do not set pkcs11 pin path in openssl-engine.conf

### DIFF
--- a/recipes-connectivity/openssl/files/openssl-aos.cnf
+++ b/recipes-connectivity/openssl/files/openssl-aos.cnf
@@ -18,5 +18,4 @@ module = @LEGACY_PROVIDER_PATH@
 module = @PKCS11_PROVIDER_PATH@
 pkcs11-module-path = @HSM_MODULE_PATH@
 pkcs11-module-cache-keys = false
-pkcs11-module-token-pin = @PKCS11_PIN_PATH@
 activate = 1

--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,20 +1,18 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://openssl-engine.conf"
+SRC_URI += "file://openssl-aos.cnf"
 
 PKCS11_PROVIDER_PATH ?= "${libdir}/ossl-modules/pkcs11.so"
 LEGACY_PROVIDER_PATH ?= "${libdir}/ossl-modules/legacy.so"
 HSM_MODULE_PATH ?= "${libdir}/softhsm/libsofthsm2.so"
-PKCS11_PIN_PATH ?= "file:/var/aos/iam/.usrpin"
 
 do_install:append:class-target() {
-    if ! grep -q "^\[pkcs11_sect\]" ${D}${sysconfdir}/ssl/openssl.cnf; then
-        sed -e 's,@PKCS11_PROVIDER_PATH@,${PKCS11_PROVIDER_PATH},g' \
-            -e 's,@LEGACY_PROVIDER_PATH@,${LEGACY_PROVIDER_PATH},g' \
-            -e 's,@HSM_MODULE_PATH@,${HSM_MODULE_PATH},g' \
-            -e 's,@PKCS11_PIN_PATH@,${PKCS11_PIN_PATH},g' \
-            ${WORKDIR}/openssl-engine.conf >> ${D}${sysconfdir}/ssl/openssl.cnf
-    fi
+    sed -e 's,@PKCS11_PROVIDER_PATH@,${PKCS11_PROVIDER_PATH},g' \
+        -e 's,@LEGACY_PROVIDER_PATH@,${LEGACY_PROVIDER_PATH},g' \
+        -e 's,@HSM_MODULE_PATH@,${HSM_MODULE_PATH},g' \
+        ${WORKDIR}/openssl-aos.cnf > ${D}${sysconfdir}/ssl/openssl-aos.cnf
+
+    echo ".include ${sysconfdir}/ssl/openssl-aos.cnf" >> ${D}${sysconfdir}/ssl/openssl.cnf
 }
 
 PREFERRED_VERSION_pkcs11-provider = "1.0"


### PR DESCRIPTION
This option should be platform specific, as some platforms might not have a pin file at all.