### PR TITLE
recipes-support: add benchmark-network recipe for iperf3/sockperf servers

### DIFF
--- a/recipes-core/images/aos-image.inc
+++ b/recipes-core/images/aos-image.inc
@@ -107,6 +107,7 @@ IMAGE_INSTALL:append = " \
         cgroup-exporter \
         event-exporter \
         benchmark-target \
+        benchmark-network \
         iperf3 \
         fio \
         sockperf \

--- a/recipes-support/benchmark-network/benchmark-network.bb
+++ b/recipes-support/benchmark-network/benchmark-network.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "Starts multiple iperf3/sockperf servers, bound to a given address, for the network \
+bandwidth/latency benchmarks' service-to-unit/service-to-external-host scenarios"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://iperf3-servers.sh \
+    file://sockperf-servers.sh \
+"
+
+S = "${WORKDIR}"
+
+FILES:${PN} = " \
+    ${aos_opt_dir} \
+"
+
+RDEPENDS:${PN} = " \
+    bash \
+    iperf3 \
+    sockperf \
+"
+
+do_install() {
+    install -d ${D}${aos_opt_dir}/benchmark
+    install -m 0755 ${S}/iperf3-servers.sh ${D}${aos_opt_dir}/benchmark
+    install -m 0755 ${S}/sockperf-servers.sh ${D}${aos_opt_dir}/benchmark
+}

--- a/recipes-support/benchmark-network/files/iperf3-servers.sh
+++ b/recipes-support/benchmark-network/files/iperf3-servers.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Starts one or more iperf3 servers bound to a specific address, one per port starting at
+# --start-port, for the network bandwidth benchmark's "service to unit"/"service to external
+# host" scenarios (see aos_core_cpp/doc/benchmark_execution.md, "Network" / "Bandwidth" chapter).
+#
+# Runs in the foreground until interrupted (Ctrl+C) or terminated, then stops every iperf3
+# server it started.
+
+set -e
+
+NUM_INSTANCES=1
+START_PORT=5201
+BIND_ADDRESS=
+
+usage() {
+    echo "Usage: $(basename "$0") -b BIND_ADDRESS [-n NUM_INSTANCES] [-p START_PORT]"
+    echo
+    echo "  -b BIND_ADDRESS   address to bind each iperf3 server to (required)"
+    echo "  -n NUM_INSTANCES  number of iperf3 servers to start (default: 1)"
+    echo "  -p START_PORT     first port to bind; servers use START_PORT..START_PORT+NUM_INSTANCES-1"
+    echo "                    (default: 5201)"
+    echo
+    echo "Runs in the foreground; press Ctrl+C to stop every server it started."
+    exit 1
+}
+
+while getopts "b:n:p:h" opt; do
+    case "$opt" in
+    b) BIND_ADDRESS="$OPTARG" ;;
+    n) NUM_INSTANCES="$OPTARG" ;;
+    p) START_PORT="$OPTARG" ;;
+    h | *) usage ;;
+    esac
+done
+
+[ -n "$BIND_ADDRESS" ] || usage
+
+PIDS=""
+CLEANED_UP=""
+
+cleanup() {
+    [ -z "$CLEANED_UP" ] || return 0
+    CLEANED_UP=1
+
+    if [ -n "$PIDS" ]; then
+        echo "Stopping iperf3 server(s):$PIDS"
+        # shellcheck disable=SC2086
+        kill $PIDS 2>/dev/null || true
+        wait 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+for i in $(seq 0 $((NUM_INSTANCES - 1))); do
+    port=$((START_PORT + i))
+    log="/tmp/iperf3-${BIND_ADDRESS}-${port}.log"
+
+    iperf3 -s -p "$port" -B "$BIND_ADDRESS" </dev/null >"$log" 2>&1 &
+    PIDS="$PIDS $!"
+
+    echo "Started iperf3 server on ${BIND_ADDRESS}:${port} (pid $!, log: ${log})"
+done
+
+echo "Press Ctrl+C to stop all servers."
+
+wait

--- a/recipes-support/benchmark-network/files/sockperf-servers.sh
+++ b/recipes-support/benchmark-network/files/sockperf-servers.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Starts one or more sockperf server pairs (one UDP, one TCP) bound to a specific address, one
+# pair per port starting at --start-port, for the network latency benchmark's "service to
+# unit"/"service to external host" scenarios (see aos_core_cpp/doc/benchmark_execution.md,
+# "Network" / "Latency" chapter).
+#
+# Runs in the foreground until interrupted (Ctrl+C) or terminated, then stops every sockperf
+# server it started.
+
+set -e
+
+NUM_INSTANCES=1
+START_PORT=11111
+BIND_ADDRESS=
+
+usage() {
+    echo "Usage: $(basename "$0") -b BIND_ADDRESS [-n NUM_INSTANCES] [-p START_PORT]"
+    echo
+    echo "  -b BIND_ADDRESS   address to bind each sockperf server pair to (required)"
+    echo "  -n NUM_INSTANCES  number of sockperf server pairs to start (default: 1)"
+    echo "  -p START_PORT     first port to bind; pairs use START_PORT..START_PORT+NUM_INSTANCES-1"
+    echo "                    (default: 11111)"
+    echo
+    echo "Runs in the foreground; press Ctrl+C to stop every server it started."
+    exit 1
+}
+
+while getopts "b:n:p:h" opt; do
+    case "$opt" in
+    b) BIND_ADDRESS="$OPTARG" ;;
+    n) NUM_INSTANCES="$OPTARG" ;;
+    p) START_PORT="$OPTARG" ;;
+    h | *) usage ;;
+    esac
+done
+
+[ -n "$BIND_ADDRESS" ] || usage
+
+PIDS=""
+CLEANED_UP=""
+
+cleanup() {
+    [ -z "$CLEANED_UP" ] || return 0
+    CLEANED_UP=1
+
+    if [ -n "$PIDS" ]; then
+        echo "Stopping sockperf server(s):$PIDS"
+        # shellcheck disable=SC2086
+        kill $PIDS 2>/dev/null || true
+        wait 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+for i in $(seq 0 $((NUM_INSTANCES - 1))); do
+    port=$((START_PORT + i))
+    udp_log="/tmp/sockperf-${BIND_ADDRESS}-${port}-udp.log"
+    tcp_log="/tmp/sockperf-${BIND_ADDRESS}-${port}-tcp.log"
+
+    sockperf server -i "$BIND_ADDRESS" -p "$port" </dev/null >"$udp_log" 2>&1 &
+    PIDS="$PIDS $!"
+    echo "Started sockperf UDP server on ${BIND_ADDRESS}:${port} (pid $!, log: ${udp_log})"
+
+    sockperf server -i "$BIND_ADDRESS" -p "$port" --tcp </dev/null >"$tcp_log" 2>&1 &
+    PIDS="$PIDS $!"
+    echo "Started sockperf TCP server on ${BIND_ADDRESS}:${port} (pid $!, log: ${tcp_log})"
+done
+
+echo "Press Ctrl+C to stop all servers."
+wait


### PR DESCRIPTION
Adds helper scripts to start multiple iperf3/sockperf server instances bound to a given address, for the network bandwidth/latency benchmark scenarios, and installs the recipe into the image.