### PR TITLE
recipes-containers: fix crun do_configure failure from GNUmakefile

### DIFF
--- a/recipes-containers/crun/crun_git.bbappend
+++ b/recipes-containers/crun/crun_git.bbappend
@@ -1,1 +1,8 @@
 EXTRA_OECONF:append = " --enable-shared"
+
+# crun ships its own top-level GNUmakefile that only forwards to the
+# real build once ./autogen.sh && ./configure have run. OE's
+# autotools_preconfigure runs "make clean" before that point and picks
+# up this GNUmakefile (make prefers it over Makefile), hitting its
+# "abort-due-to-no-makefile" guard target and failing do_configure.
+CLEANBROKEN = "1"


### PR DESCRIPTION
crun ships a top-level GNUmakefile that only forwards to the real build after autogen.sh/configure have run. OE's autotools_preconfigure runs "make clean" before that, picks up GNUmakefile (make prefers it over Makefile), and hits its abort-due-to-no-makefile guard, failing do_configure. Set CLEANBROKEN to skip that step.